### PR TITLE
Slicer build base auto update

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+$script_dir/slicer-build-base/build.sh && \
+$script_dir/slicer-build-deps/build.sh && \
+$script_dir/slicer-build/build.sh
+

--- a/push.sh
+++ b/push.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+$script_dir/slicer-build-base/push.sh && \
+$script_dir/slicer-build-deps/push.sh && \
+$script_dir/slicer-build/push.sh

--- a/slicer-build-base/Dockerfile
+++ b/slicer-build-base/Dockerfile
@@ -45,8 +45,8 @@ RUN wget http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-open
   rm -rf /usr/src/install-prefix/doc
 ENV PATH /usr/src/install-prefix/bin:$PATH
 
-# Slicer master 2016-06-14
-ENV SLICER_VERSION 25193
+# Slicer master 2016-06-19
+ENV SLICER_VERSION 25199
 RUN svn checkout -r ${SLICER_VERSION} http://svn.slicer.org/Slicer4/trunk Slicer && \
   cd Slicer && \
   rm -rf .svn

--- a/slicer-build-base/Dockerfile
+++ b/slicer-build-base/Dockerfile
@@ -45,8 +45,8 @@ RUN wget http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-open
   rm -rf /usr/src/install-prefix/doc
 ENV PATH /usr/src/install-prefix/bin:$PATH
 
-# Slicer master 2016-06-19
-ENV SLICER_VERSION 25199
+# Slicer master 2016-06-21
+ENV SLICER_VERSION 25201
 RUN svn checkout -r ${SLICER_VERSION} http://svn.slicer.org/Slicer4/trunk Slicer && \
   cd Slicer && \
   rm -rf .svn

--- a/slicer-build-base/push.sh
+++ b/slicer-build-base/push.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+docker push slicer/$(basename $script_dir)

--- a/slicer-build-base/update.py
+++ b/slicer-build-base/update.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import subprocess
+
+#
+# Usage:
+#
+#   $ ./update.py svn_revision svn_revision_date
+#
+# Example:
+#
+#   $ ./update.py 25199 2016-06-19
+#
+
+def update_dockerfile(dockerfile, svn_revison, svn_revision_date):
+    lines = []
+    with open(dockerfile) as f:
+        for line in f:
+            if 'ENV SLICER_VERSION' in line:
+                line = "ENV SLICER_VERSION %s\n" % svn_revison
+            if '# Slicer master ' in line:
+                line = "# Slicer master %s\n" % svn_revision_date
+            lines.append(line)
+    with open(dockerfile, 'w') as f:
+        f.writelines(lines)
+        print("File %s updated\n" % dockerfile)
+
+def _run(cmd):
+    print("Executing %s" % ' '.join(cmd))
+    subprocess.check_call(cmd)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Update "slicer-build-base/Dockerfile" and git commit.')
+    parser.add_argument("svn_revision")
+    parser.add_argument("svn_revision_date")
+    args = parser.parse_args()
+
+    slicer_build_base_dir = os.path.dirname(__file__)
+    dockerfile = os.path.join(slicer_build_base_dir, "Dockerfile")
+
+    update_dockerfile(dockerfile, args.svn_revision, args.svn_revision_date)
+
+    _run(['git', 'add', dockerfile])
+    message = 'ENH: slicer-build-base: Update to Slicer r%s from %s' % (args.svn_revision, args.svn_revision_date)
+    _run(['git', 'commit', '-m', message])
+

--- a/slicer-build-base/update.sh
+++ b/slicer-build-base/update.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#
+# Usage:
+#
+#  $ ./update.sh /path/to/src/Slicer
+#
+# Example:
+#
+#  $ ./update.sh ~/Projects/Slicer
+#  slicer_dir:/home/jcfr/Projects/Slicer
+#  svn_revision: 25199
+#  svn_revision_date: 2016-06-19
+#
+#  File /home/jcfr/Projects/SlicerDocker/slicer-build-base/Dockerfile updated
+#
+#  Executing git add /home/jcfr/Projects/SlicerDocker/slicer-build-base/Dockerfile
+#
+#  Executing git commit -m ENH: slicer-build-base: Update to Slicer r25199 from 2016-06-19
+#  [master 397eeab] ENH: slicer-build-base: Update to Slicer r25199 from 2016-06-19
+#   1 file changed, 2 insertions(+), 2 deletions(-)
+#
+
+script_dir="`cd $(dirname $0); pwd`"
+
+if test -z "$1"; then
+  echo "Usage: $0 /path/to/src/Slicer"
+  exit 1
+fi
+
+slicer_dir=$1
+
+echo "slicer_dir:$slicer_dir"
+
+pushd $slicer_dir > /dev/null 2>&1
+
+svn_revision=$(git svn info | grep "Last Changed Rev" | sed -e 's/Last Changed Rev: //g')
+echo "svn_revision: $svn_revision"
+
+svn_revision_date=$(git svn info | grep "Last Changed Date" | sed -e 's/Last Changed Date: //g' | cut -d" " -f1)
+echo "svn_revision_date: $svn_revision_date"
+
+popd > /dev/null 2>&1
+echo ""
+
+python $script_dir/update.py $svn_revision $svn_revision_date
+

--- a/slicer-build-deps/push.sh
+++ b/slicer-build-deps/push.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+docker push slicer/$(basename $script_dir)

--- a/slicer-build/push.sh
+++ b/slicer-build/push.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+script_dir="`cd $(dirname $0); pwd`"
+
+docker push slicer/$(basename $script_dir)


### PR DESCRIPTION
To facilitate the updated of `slicer-build-base/Dockerfile`, I added the script `updated.sh` (and its companion script `update.py`)

Given the path to a Slicer source tree (setup with git-svn) it will update the Dockerfile and add a commit.

Todo:
* [ ] Support regular SVN checkout


@msmolens Let me know what you think.