### PR TITLE
ENH: slicer-base: Update to Slicer r25536 from 2016-11-14

### DIFF
--- a/slicer-base/Dockerfile
+++ b/slicer-base/Dockerfile
@@ -46,7 +46,7 @@ RUN wget http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-open
 ENV PATH /usr/src/install-prefix/bin:$PATH
 
 # Slicer master 2016-11-14
-ENV SLICER_VERSION 25534
+ENV SLICER_VERSION 25536
 RUN svn checkout -r ${SLICER_VERSION} http://svn.slicer.org/Slicer4/trunk Slicer && \
   cd Slicer && \
   rm -rf .svn


### PR DESCRIPTION
@jcfr Note that every time [SuperBuild](https://github.com/Slicer/Slicer/tree/master/SuperBuild) is modified, we have to update the docker images.

If not, we'll have an error in CircleCI during the automatic build/run tests
![circleci-error](https://cloud.githubusercontent.com/assets/20341270/20284749/786d7454-aa8c-11e6-9b65-95c3ea81a982.png)
