### PR TITLE
ENH: slicer-base: Update to Slicer r25639 from 2017-01-12

### DIFF
--- a/slicer-base/Dockerfile
+++ b/slicer-base/Dockerfile
@@ -45,8 +45,8 @@ RUN wget http://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-open
   rm -rf /usr/src/install-prefix/doc
 ENV PATH /usr/src/install-prefix/bin:$PATH
 
-# Slicer master 2017-01-06
-ENV SLICER_VERSION 25633
+# Slicer master 2017-01-12
+ENV SLICER_VERSION 25639
 RUN svn checkout -r ${SLICER_VERSION} http://svn.slicer.org/Slicer4/trunk Slicer && \
   cd Slicer && \
   rm -rf .svn


### PR DESCRIPTION
I verified this time to be on the updated slicer master branch before launching the `./slicer-base/update.sh` script.

Sorry for the mistake on the PR https://github.com/thewtex/SlicerDocker/pull/29