### PR TITLE
Updated to work with Slicer 4.13 preview releases.

### DIFF
--- a/slicer-notebook/Dockerfile
+++ b/slicer-notebook/Dockerfile
@@ -26,6 +26,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' >> /etc/apt
 #   - basic  tools
 #   - slicer dependencies
 #   - awesome window manager
+#   - install ca-certs to prevent - fatal: unable to access 'https://github.com/novnc/websockify/': server certificate verification failed. CAfile: none CRLfile: none
 RUN apt-get install -q -y \
  vim net-tools curl \
  libgl1-mesa-glx \
@@ -63,15 +64,9 @@ WORKDIR ${HOME}
 # Download and unpack Slicer
 
 # Current preview release
-#ARG SLICER_ARCHIVE=Slicer-4.13.0-2021-10-07-linux-amd64
 ARG SLICER_DOWNLOAD_URL=https://download.slicer.org/bitstream/615fc637342a877cb3cd343f
 
-# Current stable release - this currently fails due to mising SlicerJupyter
-#ARG SLICER_ARCHIVE=Slicer-4.11.20210226-linux-amd64
-#ARG SLICER_DOWNLOAD_URL=https://download.slicer.org/bitstream/60add706ae4540bf6a89bf98
-
-# Previous stable release - this works
-#ARG SLICER_ARCHIVE=Slicer-4.11.20200930-linux-amd64
+# Latest working Slicer-4.11 version (SlicerJupyter extension is not available for the more recent Slicer-4.11.20210226 version)
 #ARG SLICER_DOWNLOAD_URL=https://download.slicer.org/bitstream/60add70fae4540bf6a89bfb4
 
 # Use local package:
@@ -87,11 +82,6 @@ ENV JUPYTERPORT=8888
 ENV DISPLAY=:10
 
 COPY xorg.conf .
-
-# Prevent git error:
-#   fatal: unable to access 'https://github.com/novnc/websockify/': server certificate verification failed. CAfile: none CRLfile: none
-#RUN apt-get -y -q install git && \
-#    apt-get install --reinstall ca-certificates
 
 ################################################################################
 # Set up remote desktop access - step 1/2

--- a/slicer-notebook/install.sh
+++ b/slicer-notebook/install.sh
@@ -35,12 +35,10 @@ echo "Install SlicerJupyter extension"
 $slicer_executable -c '
 em = slicer.app.extensionsManagerModel()
 extensionMetaData = em.retrieveExtensionMetadataByName("SlicerJupyter")
-print(f"extensionMetaData: {extensionMetaData}")
 if slicer.app.majorVersion*100+slicer.app.minorVersion < 413:
     # Slicer-4.11
     itemId = extensionMetaData["item_id"]
     url = f"{em.serverUrl().toString()}/download?items={itemId}"
-    print(f"itemId: {itemId} url: {url}")
     extensionPackageFilename = f"{slicer.app.temporaryPath}/{itemId}"
     slicer.util.downloadFile(url, extensionPackageFilename)
 else:


### PR DESCRIPTION
**install.sh**
- now works with both 4.11 and 4.13 versions where the metadata format and download url format have changed.
- Change to use single quote escaping - makes indented python easier to read and edit

**Dockerfile**
-Updated SLICER_DOWNLOAD_URL for the current 4.13 preview release
- Simplifies the curl and extraction - no need to match SLICER_ARCHIVE value to whatever the download server decides to return.
- Added notebook jupyterhub jupyterlab modules to pip install in preparation for use on Jupyterhub
- Remove unnecessary apt-get steps (move ca-certs to top with other installs)